### PR TITLE
fix non-compliance with the С standard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   global:
     - PREFIX=${HOME}/opt
     - PATH=${PREFIX}/bin:${PATH}
-    - OPENSSL_BRANCH=master
+    - OPENSSL_BRANCH=OpenSSL_1_1_0-stable
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   global:
     - PREFIX=${HOME}/opt
     - PATH=${PREFIX}/bin:${PATH}
-    - OPENSSL_BRANCH=OpenSSL_1_1_0-stable
+    - OPENSSL_BRANCH=OpenSSL_1_1_1-stable
 
 matrix:
   include:

--- a/getopt.h
+++ b/getopt.h
@@ -115,10 +115,26 @@ static char EMSG[] = "";
 #define	EMSG		""
 #endif
 
+typedef struct option		/* specification for a long form option...	*/
+{
+  const char *name;		/* option name, without leading hyphens */
+  int         has_arg;		/* does it take an argument?		*/
+  int        *flag;		/* where to save its status, or NULL	*/
+  int         val;		/* its associated status value		*/
+}option_t;
+
+enum    		/* permitted values for its `has_arg' field...	*/
+{
+  no_argument = 0,      	/* option never takes an argument	*/
+  required_argument,		/* option always requires an argument	*/
+  optional_argument		/* option may take an argument		*/
+};
+
+
 static int getopt_internal(int, char * const *, const char *,
-			   const struct option *, int *, int);
+			   const option_t *, int *, int);
 static int parse_long_options(char * const *, const char *,
-			      const struct option *, int *, int);
+			      const option_t *, int *, int);
 static int gcd(int, int);
 static void permute_args(int, int, int, char * const *);
 
@@ -265,20 +281,6 @@ extern int optreset;
 extern "C" {
 #endif
 
-struct option		/* specification for a long form option...	*/
-{
-  const char *name;		/* option name, without leading hyphens */
-  int         has_arg;		/* does it take an argument?		*/
-  int        *flag;		/* where to save its status, or NULL	*/
-  int         val;		/* its associated status value		*/
-};
-
-enum    		/* permitted values for its `has_arg' field...	*/
-{
-  no_argument = 0,      	/* option never takes an argument	*/
-  required_argument,		/* option always requires an argument	*/
-  optional_argument		/* option may take an argument		*/
-};
 
 /*
  * parse_long_options --
@@ -287,7 +289,7 @@ enum    		/* permitted values for its `has_arg' field...	*/
  */
 static int
 parse_long_options(char * const *nargv, const char *options,
-	const struct option *long_options, int *idx, int short_too)
+	const option_t *long_options, int *idx, int short_too)
 {
 	char *current_argv, *has_equal;
 	size_t current_argv_len;
@@ -415,7 +417,7 @@ parse_long_options(char * const *nargv, const char *options,
  */
 static int
 getopt_internal(int nargc, char * const *nargv, const char *options,
-	const struct option *long_options, int *idx, int flags)
+	const option_t *long_options, int *idx, int flags)
 {
 	char *oli;				/* option letter list index */
 	int optchar, short_too;
@@ -612,7 +614,7 @@ start:
  */
 int
 getopt_long(int nargc, char * const *nargv, const char *options,
-    const struct option *long_options, int *idx)
+    const option_t *long_options, int *idx)
 {
 
 	return (getopt_internal(nargc, nargv, options, long_options, idx,
@@ -625,7 +627,7 @@ getopt_long(int nargc, char * const *nargv, const char *options,
  */
 int
 getopt_long_only(int nargc, char * const *nargv, const char *options,
-    const struct option *long_options, int *idx)
+    const option_t *long_options, int *idx)
 {
 
 	return (getopt_internal(nargc, nargv, options, long_options, idx,

--- a/gost_grasshopper_cipher.c
+++ b/gost_grasshopper_cipher.c
@@ -152,7 +152,7 @@ gost_grasshopper_cipher_key(gost_grasshopper_cipher_ctx * c, const uint8_t *k)
 }
 
 /* Set master 256-bit key to be used in TLSTREE calculation into context */
-GRASSHOPPER_INLINE void
+static GRASSHOPPER_INLINE void
 gost_grasshopper_master_key(gost_grasshopper_cipher_ctx * c, const uint8_t *k)
 {
     int i;

--- a/gost_pmeth.c
+++ b/gost_pmeth.c
@@ -25,7 +25,7 @@
 #define ossl3_const const
 #endif
 
-/* -----init, cleanup, copy - uniform for all algs  --------------*/
+/* -----init, cleanup, copy - uniform for all algs790  --------------*/
 /* Allocates new gost_pmeth_data structure and assigns it as data */
 static int pkey_gost_init(EVP_PKEY_CTX *ctx)
 {
@@ -659,7 +659,7 @@ static int pkey_gost_mac_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
                 GOSTerr(GOST_F_PKEY_GOST_MAC_CTRL, GOST_R_INVALID_MAC_SIZE);
                 return 0;
             }
-            data->mac_size = p1;
+            data->mac_size = (short int)p1;
             return 1;
         }
     }
@@ -787,12 +787,12 @@ static int pkey_gost_omac_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2, si
         }
     case EVP_PKEY_CTRL_MAC_LEN:
         {
-            if (p1 < 1 || p1 > max_size) {
+            if ((size_t)p1==0 || (size_t)p1 > max_size) {
 
                 GOSTerr(GOST_F_PKEY_GOST_OMAC_CTRL, GOST_R_INVALID_MAC_SIZE);
                 return 0;
             }
-            data->mac_size = p1;
+            data->mac_size = (short int)p1;
             return 1;
         }
     }


### PR DESCRIPTION
gost_pmeth.c 
  - make type cast explicit
  
gost_grasshopper_cipher.c
  - fix bug. "grasshopper_copy128" is static but used in inline function "gost_grasshopper_master_key" 
    which is not static. 
    make "gost_grasshopper_master_key" static
getopt.h
  - fix "struct option" type declaration. It was behind  the method declaration that use "struct option" as a parameter. Pedantic compilers complain.