### PR TITLE
fix test scenarios. adopt them for Windows

### DIFF
--- a/ansi_terminal.c
+++ b/ansi_terminal.c
@@ -1,0 +1,95 @@
+#ifdef _WIN32
+ #define  _CRT_SECURE_NO_WARNINGS 1
+ #include <windows.h>
+#else
+ #include <termios.h>
+ #include <unistd.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef _WIN32
+ // Some old MinGW/CYGWIN distributions don't define this:
+ #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+  #define ENABLE_VIRTUAL_TERMINAL_PROCESSING  0x0004
+ #endif
+
+static HANDLE stdoutHandle, stdinHandle;
+static DWORD outModeInit, inModeInit;
+
+void setupConsole(void) {
+    DWORD outMode = 0, inMode = 0;
+    stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+    stdinHandle = GetStdHandle(STD_INPUT_HANDLE);
+
+    if(stdoutHandle == INVALID_HANDLE_VALUE || stdinHandle == INVALID_HANDLE_VALUE) {
+        exit(GetLastError());
+    }
+    
+    if(!GetConsoleMode(stdoutHandle, &outMode) || !GetConsoleMode(stdinHandle, &inMode)) {
+        exit(GetLastError());
+    }
+
+    outModeInit = outMode;
+    inModeInit = inMode;
+    
+    // Enable ANSI escape codes
+    outMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+
+    // Set stdin as no echo and unbuffered
+    inMode &= ~(ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT);
+
+    if(!SetConsoleMode(stdoutHandle, outMode) || !SetConsoleMode(stdinHandle, inMode)) {
+        exit(GetLastError());
+    }    
+}
+
+void restoreConsole(void) {
+    // Reset colors
+    printf("\x1b[0m");    
+    
+    // Reset console mode
+    if(!SetConsoleMode(stdoutHandle, outModeInit) || !SetConsoleMode(stdinHandle, inModeInit)) {
+        exit(GetLastError());
+    }
+}
+#else
+
+static struct termios orig_term;
+static struct termios new_term;
+
+void setupConsole(void) {
+    tcgetattr(STDIN_FILENO, &orig_term);
+    new_term = orig_term;
+
+    new_term.c_lflag &= ~(ICANON | ECHO);
+
+    tcsetattr(STDIN_FILENO, TCSANOW, &new_term);
+}
+
+void restoreConsole(void) {
+    // Reset colors
+    printf("\x1b[0m");
+
+    // Reset console mode
+    tcsetattr(STDIN_FILENO, TCSANOW, &orig_term);
+}
+#endif
+
+void getCursorPosition(int *row, int *col) {
+    printf("\x1b[6n");
+    char buff[128];
+    int indx = 0;
+    for(;;) {
+        int cc = getchar();
+        buff[indx] = (char)cc;
+        indx++;
+        if(cc == 'R') {
+            buff[indx + 1] = '\0';
+            break;
+        }
+    }    
+    sscanf(buff, "\x1b[%d;%dR", row, col);
+    fseek(stdin, 0, SEEK_END);
+}

--- a/ansi_terminal.h
+++ b/ansi_terminal.h
@@ -1,0 +1,15 @@
+/* code adopted from https://github.com/sol-prog/ansi-escape-codes-windows-posix-terminals-c-programming-examples
+   
+*/
+
+#define cRED	"\033[1;31m"
+#define cDRED	"\033[0;31m"
+#define cGREEN	"\033[1;32m"
+#define cDGREEN	"\033[0;32m"
+#define cBLUE	"\033[1;34m"
+#define cDBLUE	"\033[0;34m"
+#define cNORM	"\033[m"
+
+void setupConsole(void);
+void restoreConsole(void);
+void getCursorPosition(int *row, int *col);

--- a/test.h
+++ b/test.h
@@ -1,0 +1,61 @@
+#ifndef TEST_H
+#define TEST_H
+
+#define T(e) do{    if (!(e)) {\
+	  ERR_print_errors_fp(stderr);\
+	  OpenSSLDie(__FILE__, __LINE__, #e); }\
+        }while (0)
+
+#define TE(e) do{ if (!(e)) { \
+                ERR_print_errors_fp(stderr); \
+                fprintf(stderr, "Error at %s:%d %s\n", __FILE__, __LINE__, #e); \
+                return -1; } }while (0) 
+
+#define TEST_ASSERT(e) do{ test = (e);}while (0); if (test) \
+           printf(cRED "  Test FAILED\n" cNORM); \
+        else \
+           printf(cGREEN "  Test passed\n" cNORM)\
+             
+
+
+
+static void hexdump(FILE *f, const char *title, const unsigned char *s, int l)
+{
+    int n = 0;
+
+    if(title!=NULL) fprintf(f, "%s", title);
+    for (; n < l; ++n) {
+        if ((n % 16) == 0)
+            fprintf(f, "\n%04x", n);
+        fprintf(f, " %02x", s[n]);
+    }
+    fprintf(f, "\n");
+}
+
+static void hexdump_inline(const void *ptr, size_t len)
+{
+    const unsigned char *p = ptr;
+    size_t i, j;
+
+    for (i = 0; i < len; i += j) {
+	for (j = 0; j < 16 && i + j < len; j++)
+	    printf("%s%02x", j? "" : " ", p[i + j]);
+    }
+    printf("\n");
+}
+
+
+
+#ifdef _WIN32
+ #include <stdlib.h>
+ static inline int setenv(const char* name, const char* value,int overwrite){
+    return _putenv_s(name, value);
+ }
+#else
+ #include <unistd.h>
+ #include <arpa/inet.h>
+#endif
+
+#endif       
+
+

--- a/test_context.c
+++ b/test_context.c
@@ -11,40 +11,14 @@
 #include "gost_grasshopper_core.h"
 #include "e_gost_err.h"
 #include "gost_lcl.h"
+#include "test.h"
+#include "ansi_terminal.h"
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <openssl/err.h>
 #include <openssl/asn1.h>
 #include <string.h>
 
-#define T(e) if (!(e)) {\
-	ERR_print_errors_fp(stderr);\
-	OpenSSLDie(__FILE__, __LINE__, #e);\
-    }
-
-#define cRED	"\033[1;31m"
-#define cDRED	"\033[0;31m"
-#define cGREEN	"\033[1;32m"
-#define cDGREEN	"\033[0;32m"
-#define cBLUE	"\033[1;34m"
-#define cDBLUE	"\033[0;34m"
-#define cNORM	"\033[m"
-#define TEST_ASSERT(e) {if ((test = (e))) \
-		 printf(cRED "  Test FAILED\n" cNORM); \
-	     else \
-		 printf(cGREEN "  Test passed\n" cNORM);}
-
-static void hexdump(const void *ptr, size_t len)
-{
-    const unsigned char *p = ptr;
-    size_t i, j;
-
-    for (i = 0; i < len; i += j) {
-	for (j = 0; j < 16 && i + j < len; j++)
-	    printf("%s%02x", j? "" : " ", p[i + j]);
-    }
-    printf("\n");
-}
 
 #define TEST_SIZE 256
 #define STEP_SIZE 16
@@ -61,6 +35,7 @@ static int test_contexts(const EVP_CIPHER *type, const int enc, const char *msg,
     int outlen, tmplen;
     int ret = 0, test = 0;
 
+    
     printf(cBLUE "%s test for %s\n" cNORM, enc ? "Encryption" : "Decryption", msg);
 
     /* produce base encryption */
@@ -99,13 +74,13 @@ static int test_contexts(const EVP_CIPHER *type, const int enc, const char *msg,
 
     outlen = i * GRASSHOPPER_BLOCK_SIZE;
     T(EVP_CipherFinal_ex(ctx, c + outlen, &tmplen));
-    TEST_ASSERT(outlen != TEST_SIZE || memcmp(c, b, TEST_SIZE));
+    TEST_ASSERT(outlen != TEST_SIZE || memcmp(c, b, TEST_SIZE) );
     EVP_CIPHER_CTX_free(ctx);
     if (test) {
 	printf("  b[%d] = ", outlen);
-	hexdump(b, outlen);
+	hexdump_inline(b, outlen);
 	printf("  c[%d] = ", outlen);
-	hexdump(c, outlen);
+	hexdump_inline(c, outlen);
     }
     ret |= test;
 
@@ -120,12 +95,13 @@ static int test_contexts(const EVP_CIPHER *type, const int enc, const char *msg,
     EVP_CIPHER_CTX_free(save);
     if (test) {
 	printf("  b[%d] = ", outlen);
-	hexdump(b, outlen);
+	hexdump_inline(b, outlen);
 	printf("  c[%d] = ", outlen);
-	hexdump(c, outlen);
+	hexdump_inline(c, outlen);
     }
     ret |= test;
 
+    
     return ret;
 }
 
@@ -133,7 +109,7 @@ static int test_contexts(const EVP_CIPHER *type, const int enc, const char *msg,
 int main(int argc, char **argv)
 {
     int ret = 0;
-
+    setupConsole();
     ret |= test_contexts(cipher_gost_grasshopper_ecb(), 1, "grasshopper ecb", 0);
     ret |= test_contexts(cipher_gost_grasshopper_ecb(), 0, "grasshopper ecb", 0);
     ret |= test_contexts(cipher_gost_grasshopper_cbc(), 1, "grasshopper cbc", 0);
@@ -149,5 +125,6 @@ int main(int argc, char **argv)
 	printf(cDRED "= Some tests FAILED!\n" cNORM);
     else
 	printf(cDGREEN "= All tests passed!\n" cNORM);
+    restoreConsole();
     return ret;
 }

--- a/test_curves.c
+++ b/test_curves.c
@@ -7,6 +7,8 @@
 
 #include "e_gost_err.h"
 #include "gost_lcl.h"
+#include "test.h"
+#include "ansi_terminal.h"
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <openssl/err.h>
@@ -16,29 +18,12 @@
 #include <openssl/bn.h>
 #include <string.h>
 
-#define T(e) ({ if (!(e)) { \
-		ERR_print_errors_fp(stderr); \
-		OpenSSLDie(__FILE__, __LINE__, #e); \
-	    } \
-        })
-
-#define cRED	"\033[1;31m"
-#define cDRED	"\033[0;31m"
-#define cGREEN	"\033[1;32m"
-#define cDGREEN	"\033[0;32m"
-#define cBLUE	"\033[1;34m"
-#define cDBLUE	"\033[0;34m"
-#define cNORM	"\033[m"
-#define TEST_ASSERT(e) {if ((test = (e))) \
-		 printf(cRED "  Test FAILED\n" cNORM); \
-	     else \
-		 printf(cGREEN "  Test passed\n" cNORM);}
-
 struct test_curve {
     int nid;
     const char *name;
     int listed;
 };
+
 
 static struct test_curve test_curves[] = {
 #if 2001
@@ -80,7 +65,7 @@ static void print_bn(const char *name, const BIGNUM *n)
 static int parameter_test(struct test_curve *tc)
 {
     const int nid = tc->nid;
-    int test;
+    int test=0;
 
     printf(cBLUE "Test curve NID %d" cNORM, nid);
     if (tc->name)
@@ -214,14 +199,14 @@ static int parameter_test(struct test_curve *tc)
 
     BN_CTX_free(ctx);
     EC_KEY_free(ec);
-    TEST_ASSERT(0);
     return test;
 }
 
 int main(int argc, char **argv)
 {
     int ret = 0;
-
+    
+    setupConsole();
     setenv("OPENSSL_ENGINES", ENGINE_DIR, 0);
     OPENSSL_add_all_algorithms_conf();
     ERR_load_crypto_strings();
@@ -242,5 +227,7 @@ int main(int argc, char **argv)
 	printf(cDRED "= Some tests FAILED!\n" cNORM);
     else
 	printf(cDGREEN "= All tests passed!\n" cNORM);
+    
+    restoreConsole();
     return ret;
 }

--- a/test_digest.c
+++ b/test_digest.c
@@ -9,6 +9,8 @@
 
 #include "e_gost_err.h"
 #include "gost_lcl.h"
+#include "test.h"
+#include "ansi_terminal.h"
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <openssl/err.h>
@@ -20,29 +22,6 @@
 # include <sys/sysmips.h>
 #endif
 
-#define T(e) ({ if (!(e)) { \
-		ERR_print_errors_fp(stderr); \
-		OpenSSLDie(__FILE__, __LINE__, #e); \
-	    } \
-        })
-#define TE(e) ({ if (!(e)) { \
-		ERR_print_errors_fp(stderr); \
-		fprintf(stderr, "Error at %s:%d %s\n", __FILE__, __LINE__, #e); \
-		return -1; \
-	    } \
-        })
-
-#define cRED	"\033[1;31m"
-#define cDRED	"\033[0;31m"
-#define cGREEN	"\033[1;32m"
-#define cDGREEN	"\033[0;32m"
-#define cBLUE	"\033[1;34m"
-#define cDBLUE	"\033[0;34m"
-#define cNORM	"\033[m"
-#define TEST_ASSERT(e) {if ((test = (e))) \
-		 printf(cRED "  Test FAILED\n" cNORM); \
-	     else \
-		 printf(cGREEN "  Test passed\n" cNORM);}
 
 struct hash_testvec {
 	int nid;
@@ -123,6 +102,36 @@ static const struct hash_testvec testvecs[] = {
 			"\x3f\x0c\xb9\xdd\xdc\x2b\x64\x60"
 			"\x14\x3b\x03\xda\xba\xc9\xfb\x28",
 	},
+	{ /* M5 */
+		.nid = NID_id_GostR3411_2012_256,
+		.name = "M5",
+		.plaintext =
+			"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
+			"\x00\x00\x00\x00\x00\x00\x00\x00"
+			"\x00\x00\x00\x00\x00\x00\x00\x00"
+			"\x3e\x00\x03\x00\xfe\xff\x09\x00"
+			"\x06\x00\x00\x00\x00\x00\x00\x00"
+			"\x00\x00\x00\x00\x01\x00\x00\x00"
+			"\x01\x00\x00\x00\x00\x00\x00\x00"
+			"\x00\x10\x00\x00\x24\x00\x00\x00"
+			"\x01\x00\x00\x00\xfe\xff\xff\xff"
+			"\x00\x00\x00\x00\x00\x00\x00\x00"
+			"\xff\xff\xff\xff\xff\xff\xff\xff"
+			"\xff\xff\xff\xff\xff\xff\xff\xff"
+			"\xff\xff\xff\xff\xff\xff\xff\xff"
+			"\xff\xff\xff\xff\xff\xff\xff\xff"
+			"\xff\xff\xff\xff\xff\xff\xff\xff"
+			"\xff\xff\xff\xff\xff\xff\xff\xff"
+			"\xff\xff\xff\xff\xff\xff\xff\xff"
+			"\xff\xff\xff\xff\xff\xff\xff\xff",
+		.psize = 144,
+		.digest =
+			"\xc7\x66\x08\x55\x40\xca\xaa\x89"
+			"\x53\xbf\xcf\x7a\x1b\xa2\x20\x61"
+			"\x9c\xee\x50\xd6\x5d\xc2\x42\xf8"
+			"\x2f\x23\xba\x4b\x18\x0b\x18\xe0",
+	},
+
 	{ 0 }
 };
 
@@ -130,20 +139,17 @@ static int do_digest(int hash_nid, const char *plaintext, unsigned int psize,
     const char *etalon)
 {
 	unsigned int mdlen = 0;
+	unsigned int len;
+	unsigned char md[512 / 8];
+        const EVP_MD *mdtype;
+
 	if (hash_nid == NID_id_GostR3411_2012_256)
 		mdlen = 256 / 8;
 	else if (hash_nid == NID_id_GostR3411_2012_512)
 		mdlen = 512 / 8;
-	const EVP_MD *mdtype;
+	
 	T(mdtype = EVP_get_digestbynid(hash_nid));
-	EVP_MD_CTX *ctx;
-	T(ctx = EVP_MD_CTX_new());
-	T(EVP_DigestInit(ctx, mdtype));
-	T(EVP_DigestUpdate(ctx, plaintext, psize));
-	unsigned int len;
-	unsigned char md[512 / 8];
-	T(EVP_DigestFinal(ctx, md, &len));
-	EVP_MD_CTX_free(ctx);
+	EVP_Digest(plaintext, psize, md, &len, mdtype, NULL);
 	if (len != mdlen) {
 		printf(cRED "digest output len mismatch %u != %u (expected)\n" cNORM,
 		    len, mdlen);
@@ -151,7 +157,34 @@ static int do_digest(int hash_nid, const char *plaintext, unsigned int psize,
 	}
 	if (memcmp(md, etalon, mdlen) != 0) {
 		printf(cRED "digest mismatch\n" cNORM);
+                hexdump(stdout, "actial", md, mdlen ); 
+		hexdump(stdout, "expected", (const unsigned char*)etalon, mdlen );
 		return 1;
+	}
+	
+	/* small chunk test. split data on 63+64+rest*/
+	if( psize>128 ){
+		EVP_MD_CTX *ctx;		
+		T(ctx = EVP_MD_CTX_new());
+		T(EVP_DigestInit(ctx, mdtype));
+		T(EVP_DigestUpdate(ctx, plaintext, 63));
+		T(EVP_DigestUpdate(ctx, plaintext + 63, 64));
+		T(EVP_DigestUpdate(ctx, plaintext + 63 + 64, psize - 63 - 64));
+		
+		T(EVP_DigestFinal(ctx, md, &len));
+		EVP_MD_CTX_free(ctx);
+		
+		if (len != mdlen) {
+			printf(cRED "digest output len mismatch %u != %u (expected)\n" cNORM,
+				len, mdlen);
+			return 1;
+		}
+		
+		if (memcmp(md, etalon, mdlen) != 0) {
+			printf(cRED "digest mismatch\n" cNORM);
+			return 1;
+		}
+		
 	}
 
 	return 0;
@@ -170,7 +203,7 @@ static int do_test(const struct hash_testvec *tv)
 	fflush(stdout);
 	ret |= do_digest(tv->nid, tv->plaintext, tv->psize, tv->digest);
 
-	/* Text alignment problems. */
+	/* Test alignment problems. */
 	int shifts = 32;
 	int i;
 	char *buf;
@@ -191,7 +224,7 @@ static int do_test(const struct hash_testvec *tv)
 int main(int argc, char **argv)
 {
     int ret = 0;
-
+    setupConsole();
 #if MIPSEL
     /* Trigger SIGBUS for unaligned access. */
     sysmips(MIPS_FIXADE, 0);
@@ -215,5 +248,6 @@ int main(int argc, char **argv)
 	printf(cDRED "= Some tests FAILED!\n" cNORM);
     else
 	printf(cDGREEN "= All tests passed!\n" cNORM);
+    restoreConsole();
     return ret;
 }

--- a/test_gost2814789.c
+++ b/test_gost2814789.c
@@ -8,7 +8,6 @@
  * ====================================================================
  */
 #include <stdio.h>
-
 #include <stdlib.h>
 #include <string.h>
 #include <openssl/conf.h>
@@ -22,6 +21,7 @@
 #define CCGOST_DIR "."
 
 #include "gost89.h"
+#include "test.h"
 
 #define G89_MAX_TC_LEN	(2048)
 #define G89_BLOCK_LEN (8)

--- a/test_gost89.c
+++ b/test_gost89.c
@@ -11,19 +11,7 @@
 #include "gost89.h"
 #include <stdio.h>
 #include <string.h>
-
-static void hexdump(FILE *f, const char *title, const unsigned char *s, int l)
-{
-    int n = 0;
-
-    fprintf(f, "%s", title);
-    for (; n < l; ++n) {
-        if ((n % 16) == 0)
-            fprintf(f, "\n%04x", n);
-        fprintf(f, " %02x", s[n]);
-    }
-    fprintf(f, "\n");
-}
+#include "test.h"
 
 int main(void)
 {

--- a/test_grasshopper.c
+++ b/test_grasshopper.c
@@ -11,28 +11,26 @@
 #include "gost_grasshopper_core.h"
 #include "e_gost_err.h"
 #include "gost_lcl.h"
+#include "test.h"
+#include "ansi_terminal.h"
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <openssl/err.h>
 #include <openssl/asn1.h>
 #include <string.h>
+#include <assert.h>
+#if defined(_MSC_VER)
+  /* MSVC doesn't fully support C99 VLA. The simples workaroud  is using 
+     big static array instead.
+  */
+# define MAX_BUF_SIZE   144 
+# define DECLARE_BUF(SZ)   unsigned char c[MAX_BUF_SIZE];\
+                           assert(SZ<=MAX_BUF_SIZE);
+#else
+# define DECLARE_BUF(SZ)   unsigned char c[SZ];
+#endif
 
-#define T(e) if (!(e)) {\
-	ERR_print_errors_fp(stderr);\
-	OpenSSLDie(__FILE__, __LINE__, #e);\
-    }
 
-#define cRED	"\033[1;31m"
-#define cDRED	"\033[0;31m"
-#define cGREEN	"\033[1;32m"
-#define cDGREEN	"\033[0;32m"
-#define cBLUE	"\033[1;34m"
-#define cDBLUE	"\033[0;34m"
-#define cNORM	"\033[m"
-#define TEST_ASSERT(e) {if ((test = (e))) \
-		 printf(cRED "Test FAILED\n" cNORM); \
-	     else \
-		 printf(cGREEN "Test passed\n" cNORM);}
 
 /* Test key from both GOST R 34.12-2015 and GOST R 34.13-2015. */
 static const unsigned char K[32] = {
@@ -159,7 +157,7 @@ static const unsigned char MAC_omac_acpkm2[] = {
 
 struct testcase {
     const char *name;
-    const EVP_CIPHER *(*type)(void);
+    const EVP_CIPHER *(*type)();
     int stream;
     const unsigned char *plaintext;
     const unsigned char *expected;
@@ -181,17 +179,6 @@ static struct testcase testcases[] = {
     NULL
 };
 
-static void hexdump(const void *ptr, size_t len)
-{
-    const unsigned char *p = ptr;
-    size_t i, j;
-
-    for (i = 0; i < len; i += j) {
-	for (j = 0; j < 16 && i + j < len; j++)
-	    printf("%s%02x", j? "" : " ", p[i + j]);
-    }
-    printf("\n");
-}
 
 static int test_block(const EVP_CIPHER *type, const char *name,
     const unsigned char *pt, const unsigned char *exp, size_t size,
@@ -200,9 +187,10 @@ static int test_block(const EVP_CIPHER *type, const char *name,
 {
     EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
     const char *standard = acpkm? "R 23565.1.017-2018" : "GOST R 34.13-2015";
-    unsigned char c[size];
     int outlen, tmplen;
     int ret = 0, test;
+    
+    DECLARE_BUF(size);
 
     OPENSSL_assert(ctx);
     printf("Encryption test from %s [%s] %s\n", standard, name,
@@ -214,14 +202,14 @@ static int test_block(const EVP_CIPHER *type, const char *name,
     if (inplace)
 	memcpy(c, pt, size);
     else
-	memset(c, 0, sizeof(c));
+	memset(c, 0, size);
     if (acpkm)
 	T(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_KEY_MESH, acpkm, NULL));
     T(EVP_CipherUpdate(ctx, c, &outlen, inplace? c : pt, size));
     T(EVP_CipherFinal_ex(ctx, c + outlen, &tmplen));
     EVP_CIPHER_CTX_cleanup(ctx);
     printf("  c[%d] = ", outlen);
-    hexdump(c, outlen);
+    hexdump_inline(c, outlen);
 
     TEST_ASSERT(outlen != size || memcmp(c, exp, size));
     ret |= test;
@@ -237,7 +225,7 @@ static int test_block(const EVP_CIPHER *type, const char *name,
     if (inplace)
 	memcpy(c, pt, size);
     else
-	memset(c, 0, sizeof(c));
+	memset(c, 0, size);
     if (acpkm)
 	T(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_KEY_MESH, acpkm, NULL));
     for (z = 0; z < blocks; z++) {
@@ -250,7 +238,7 @@ static int test_block(const EVP_CIPHER *type, const char *name,
     T(EVP_CipherFinal_ex(ctx, c + outlen, &tmplen));
     EVP_CIPHER_CTX_cleanup(ctx);
     printf("  c[%d] = ", outlen);
-    hexdump(c, outlen);
+    hexdump_inline(c, outlen);
 
     TEST_ASSERT(outlen != size || memcmp(c, exp, size));
     ret |= test;
@@ -264,7 +252,7 @@ static int test_block(const EVP_CIPHER *type, const char *name,
     if (inplace)
 	memcpy(c, exp, size);
     else
-	memset(c, 0, sizeof(c));
+	memset(c, 0, size);
     if (acpkm)
 	T(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_KEY_MESH, acpkm, NULL));
     T(EVP_CipherUpdate(ctx, c, &outlen, inplace ? c : exp, size));
@@ -272,7 +260,7 @@ static int test_block(const EVP_CIPHER *type, const char *name,
     EVP_CIPHER_CTX_cleanup(ctx);
     EVP_CIPHER_CTX_free(ctx);
     printf("  d[%d] = ", outlen);
-    hexdump(c, outlen);
+    hexdump_inline(c, outlen);
 
     TEST_ASSERT(outlen != size || memcmp(c, pt, size));
     ret |= test;
@@ -288,12 +276,12 @@ static int test_stream(const EVP_CIPHER *type, const char *name,
     const char *standard = acpkm? "R 23565.1.017-2018" : "GOST R 34.13-2015";
     int ret = 0, test;
     int z;
+    DECLARE_BUF(size);
 
     OPENSSL_assert(ctx);
     /* Cycle through all lengths from 1 upto maximum size */
     printf("Stream encryption test from %s [%s] \n", standard, name);
     for (z = 1; z <= size; z++) {
-	unsigned char c[size];
 	int outlen, tmplen;
 	int sz = 0;
 	int i;
@@ -301,7 +289,7 @@ static int test_stream(const EVP_CIPHER *type, const char *name,
 	EVP_CIPHER_CTX_init(ctx);
 	T(EVP_CipherInit_ex(ctx, type, NULL, K, iv, 1));
 	T(EVP_CIPHER_CTX_set_padding(ctx, 0));
-	memset(c, 0xff, sizeof(c));
+	memset(c, 0xff, size);
 	if (acpkm)
 	    T(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_KEY_MESH, acpkm, NULL));
 	for (i = 0; i < size; i += z) {
@@ -354,7 +342,7 @@ static int test_mac(const char *name, const char *from,
     }
     EVP_MD_CTX_free(ctx);
     printf("  MAC[%u] = ", md_len);
-    hexdump(md_value, mac_size);
+    hexdump_inline(md_value, mac_size);
 
     TEST_ASSERT(md_len != mac_size ||
 	memcmp(mac, md_value, mac_size));
@@ -367,6 +355,7 @@ int main(int argc, char **argv)
     int ret = 0;
     const struct testcase *t;
 
+    setupConsole();
     setenv("OPENSSL_ENGINES", ENGINE_DIR, 0);
     OPENSSL_add_all_algorithms_conf();
     ERR_load_crypto_strings();
@@ -409,5 +398,6 @@ int main(int argc, char **argv)
 	printf(cDRED "= Some tests FAILED!\n" cNORM);
     else
 	printf(cDGREEN "= All tests passed!\n" cNORM);
+    restoreConsole();
     return ret;
 }

--- a/test_keyexpimp.c
+++ b/test_keyexpimp.c
@@ -1,4 +1,4 @@
-#include <arpa/inet.h>
+
 #include <string.h>
 #include <stdio.h>
 #include <string.h>
@@ -8,24 +8,9 @@
 #include "gost_lcl.h"
 #include "e_gost_err.h"
 #include "gost_grasshopper_cipher.h"
+#include "test.h"
+#include "ansi_terminal.h"
 
-#define T(e) if (!(e)) {\
-	ERR_print_errors_fp(stderr);\
-	OpenSSLDie(__FILE__, __LINE__, #e);\
-    }
-
-static void hexdump(FILE *f, const char *title, const unsigned char *s, int l)
-{
-    int n = 0;
-
-    fprintf(f, "%s", title);
-    for (; n < l; ++n) {
-        if ((n % 16) == 0)
-            fprintf(f, "\n%04x", n);
-        fprintf(f, " %02x", s[n]);
-    }
-    fprintf(f, "\n");
-}
 
 int main(void)
 {

--- a/test_memory.c
+++ b/test_memory.c
@@ -1,0 +1,110 @@
+/*
+ * Test GOST memory
+*/
+
+#include "e_gost_err.h"
+#include "gost_lcl.h"
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/err.h>
+#include <openssl/asn1.h>
+#include <openssl/obj_mac.h>
+#include <string.h>
+#include <stdlib.h>
+#if MIPSEL
+# include <sys/sysmips.h>
+#endif
+
+static void hexdump(const void *ptr, size_t len)
+{
+    const unsigned char *p = ptr;
+    size_t i, j;
+
+    for (i = 0; i < len; i += j) {
+	for (j = 0; j < 16 && i + j < len; j++)
+	    printf("%s%02x", j? "" : " ", p[i + j]);
+    }
+    printf("\n");
+}
+
+
+#define T(e) ({ if (!(e)) { \
+		ERR_print_errors_fp(stderr); \
+		OpenSSLDie(__FILE__, __LINE__, #e); \
+	    } \
+        })
+#define TE(e) ({ if (!(e)) { \
+		ERR_print_errors_fp(stderr); \
+		fprintf(stderr, "Error at %s:%d %s\n", __FILE__, __LINE__, #e); \
+		return -1; \
+	    } \
+        })
+
+#define cRED	"\033[1;31m"
+#define cDRED	"\033[0;31m"
+#define cGREEN	"\033[1;32m"
+#define cDGREEN	"\033[0;32m"
+#define cBLUE	"\033[1;34m"
+#define cDBLUE	"\033[0;34m"
+#define cNORM	"\033[m"
+#define TEST_ASSERT(e) {if ((test = (e))) \
+		 printf(cRED "  Test FAILED\n" cNORM); \
+	     else \
+		 printf(cGREEN "  Test passed\n" cNORM);}
+
+
+static int do_test()
+{
+	void *buf;
+	for(int i=0;i<2 * 1024;i++){
+		buf = OPENSSL_malloc(i<<1);
+		if( 0x0f &  (size_t)buf ){
+			printf(cRED "unaligned address found %p \n", buf );
+			return 1;
+		}
+		OPENSSL_free(buf);
+	} 
+	for(int i=0;i<2 * 1024;i++){
+		buf = malloc(i<<1);
+		if( 0x0f &  (size_t)buf ){
+			printf(cRED "unaligned address found %p \n", buf );
+			return 1;
+		}
+		free(buf);
+	} 		
+		
+	
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+    int ret = 0;
+#ifndef __x86_64__
+    printf(cGREEN "test skipped\n", cNORM );
+    return 0;
+#endif
+
+#if MIPSEL
+    /* Trigger SIGBUS for unaligned access. */
+    sysmips(MIPS_FIXADE, 0);
+#endif
+    setenv("OPENSSL_ENGINES", ENGINE_DIR, 0);
+    OPENSSL_add_all_algorithms_conf();
+    ERR_load_crypto_strings();
+    ENGINE *eng;
+    T(eng = ENGINE_by_id("gost"));
+    T(ENGINE_init(eng));
+    T(ENGINE_set_default(eng, ENGINE_METHOD_ALL));
+
+    do_test();
+
+    ENGINE_finish(eng);
+    ENGINE_free(eng);
+
+    if (ret)
+	printf(cDRED "= Some tests FAILED!\n" cNORM);
+    else
+	printf(cDGREEN "= All tests passed!\n" cNORM);
+    return ret;
+}

--- a/test_params.c
+++ b/test_params.c
@@ -9,6 +9,8 @@
 
 #include "e_gost_err.h"
 #include "gost_lcl.h"
+#include "test.h"
+#include "ansi_terminal.h"
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <openssl/err.h>
@@ -18,30 +20,6 @@
 #include <openssl/bn.h>
 #include <openssl/safestack.h>
 #include <string.h>
-
-#define T(e) ({ if (!(e)) { \
-		ERR_print_errors_fp(stderr); \
-		OpenSSLDie(__FILE__, __LINE__, #e); \
-	    } \
-        })
-#define TE(e) ({ if (!(e)) { \
-		ERR_print_errors_fp(stderr); \
-		fprintf(stderr, "Error at %s:%d %s\n", __FILE__, __LINE__, #e); \
-		return -1; \
-	    } \
-        })
-
-#define cRED	"\033[1;31m"
-#define cDRED	"\033[0;31m"
-#define cGREEN	"\033[1;32m"
-#define cDGREEN	"\033[0;32m"
-#define cBLUE	"\033[1;34m"
-#define cDBLUE	"\033[0;34m"
-#define cNORM	"\033[m"
-#define TEST_ASSERT(e) {if ((test = (e))) \
-		 printf(cRED "  Test FAILED\n" cNORM); \
-	     else \
-		 printf(cGREEN "  Test passed\n" cNORM);}
 
 struct test_param {
     unsigned int param;		/* NID of EC parameters */
@@ -858,17 +836,6 @@ static struct test_cert {
 };
 #undef D
 
-static void hexdump(const void *ptr, size_t len)
-{
-    const unsigned char *p = ptr;
-    size_t i, j;
-
-    for (i = 0; i < len; i += j) {
-	for (j = 0; j < 16 && i + j < len; j++)
-	    printf("%s %02x", j? "" : "\n", p[i + j]);
-    }
-    printf("\n");
-}
 
 static void print_test_result(int err)
 {
@@ -1060,7 +1027,7 @@ static int test_param(struct test_param *t)
 	T(mdtype = EVP_get_digestbynid(hash_nid));
 	T(EVP_VerifyInit(md_ctx, mdtype));
 	/* Feed byte-by-byte. */
-	int i;
+	unsigned int i;
 	for (i = 0; i < t->data_len; i++)
 	    T(EVP_VerifyUpdate(md_ctx, &t->data[i], 1));
 	err = EVP_VerifyFinal(md_ctx, sig, siglen, pkey);
@@ -1092,7 +1059,7 @@ static int test_param(struct test_param *t)
 int main(int argc, char **argv)
 {
     int ret = 0;
-
+    setupConsole();
     setenv("OPENSSL_ENGINES", ENGINE_DIR, 0);
     OPENSSL_add_all_algorithms_conf();
     ERR_load_crypto_strings();
@@ -1111,6 +1078,6 @@ int main(int argc, char **argv)
 
     ENGINE_finish(eng);
     ENGINE_free(eng);
-
+    restoreConsole();
     return ret;
 }

--- a/test_sign.c
+++ b/test_sign.c
@@ -9,6 +9,8 @@
 
 #include "e_gost_err.h"
 #include "gost_lcl.h"
+#include "test.h"
+#include "ansi_terminal.h"
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <openssl/err.h>
@@ -19,33 +21,10 @@
 #include <string.h>
 #include <stdlib.h>
 
-#define T(e) ({ if (!(e)) { \
-		ERR_print_errors_fp(stderr); \
-		OpenSSLDie(__FILE__, __LINE__, #e); \
-	    } \
-        })
-#define TE(e) ({ if (!(e)) { \
-		ERR_print_errors_fp(stderr); \
-		fprintf(stderr, "Error at %s:%d %s\n", __FILE__, __LINE__, #e); \
-		return -1; \
-	    } \
-        })
-
-#define cRED	"\033[1;31m"
-#define cDRED	"\033[0;31m"
-#define cGREEN	"\033[1;32m"
-#define cDGREEN	"\033[0;32m"
-#define cBLUE	"\033[1;34m"
-#define cDBLUE	"\033[0;34m"
-#define cNORM	"\033[m"
-#define TEST_ASSERT(e) {if ((test = (e))) \
-		 printf(cRED "  Test FAILED\n" cNORM); \
-	     else \
-		 printf(cGREEN "  Test passed\n" cNORM);}
 
 struct test_sign {
     const char *name;
-    unsigned int nid;
+    int nid;
     size_t bits;
     const char *paramset;
 };
@@ -65,18 +44,6 @@ static struct test_sign test_signs[] = {
     0
 };
 #undef D
-
-static void hexdump(const void *ptr, size_t len)
-{
-    const unsigned char *p = ptr;
-    size_t i, j;
-
-    for (i = 0; i < len; i += j) {
-	for (j = 0; j < 16 && i + j < len; j++)
-	    printf("%s %02x", j? "" : "\n", p[i + j]);
-    }
-    printf("\n");
-}
 
 static void print_test_tf(int err, int val, const char *t, const char *f)
 {
@@ -235,7 +202,7 @@ static int test_sign(struct test_sign *t)
 int main(int argc, char **argv)
 {
     int ret = 0;
-
+    setupConsole();
     setenv("OPENSSL_ENGINES", ENGINE_DIR, 0);
     OPENSSL_add_all_algorithms_conf();
     ERR_load_crypto_strings();
@@ -255,5 +222,6 @@ int main(int argc, char **argv)
 	printf(cDRED "= Some tests FAILED!\n" cNORM);
     else
 	printf(cDGREEN "= All tests passed!\n" cNORM);
+    restoreConsole();
     return ret;
 }

--- a/test_tls.c
+++ b/test_tls.c
@@ -10,6 +10,8 @@
 
 #include "e_gost_err.h"
 #include "gost_lcl.h"
+#include "test.h"
+#include "ansi_terminal.h"
 #include <openssl/evp.h>
 #include <openssl/ssl.h>
 #include <openssl/bio.h>
@@ -22,40 +24,14 @@
 #include <openssl/bn.h>
 #include <string.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <sys/wait.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
-#include <arpa/inet.h>
 #include <err.h>
 
 /* For X509_NAME_add_entry_by_txt */
 #pragma GCC diagnostic ignored "-Wpointer-sign"
-
-#define T(e) ({ if (!(e)) { \
-		ERR_print_errors_fp(stderr); \
-		OpenSSLDie(__FILE__, __LINE__, #e); \
-	    } \
-        })
-#define TE(e) ({ if (!(e)) { \
-		ERR_print_errors_fp(stderr); \
-		fprintf(stderr, "Error at %s:%d %s\n", __FILE__, __LINE__, #e); \
-		return -1; \
-	    } \
-        })
-
-#define cRED	"\033[1;31m"
-#define cDRED	"\033[0;31m"
-#define cGREEN	"\033[1;32m"
-#define cDGREEN	"\033[0;32m"
-#define cBLUE	"\033[1;34m"
-#define cDBLUE	"\033[0;34m"
-#define cNORM	"\033[m"
-#define TEST_ASSERT(e) {if ((test = (e))) \
-		 printf(cRED "  Test FAILED\n" cNORM); \
-	     else \
-		 printf(cGREEN "  Test passed\n" cNORM);}
 
 struct certkey {
     EVP_PKEY *pkey;

--- a/test_tlstree.c
+++ b/test_tlstree.c
@@ -3,18 +3,6 @@
 # include <openssl/err.h>
 # include <openssl/evp.h>
 
-static void hexdump(FILE *f, const char *title, const unsigned char *s, int l)
-{
-    int n = 0;
-
-    fprintf(f, "%s", title);
-    for (; n < l; ++n) {
-        if ((n % 16) == 0)
-            fprintf(f, "\n%04x", n);
-        fprintf(f, " %02x", s[n]);
-    }
-    fprintf(f, "\n");
-}
 
 int main(void)
 {


### PR DESCRIPTION
ansi_terminal.c
ansi_terminal.h
  - implement cross-platform colorful terminal
      
test_context.c
test_params.c
test_digest.c
test_grasshoper.c 
test_curves.c
test_gost89.c
test_sign.c
test_keyexpimp.c
test_tlstree.c 
test_tls.c
test_gost2814789.c
  - dedicate common test macros and functions (T, TE, hashdump, hashdump_inline ) in test.h
  - fix T, TE macros enveloping them in "do{...}while (0)"
  - adopt tests for Windows
  
test_digest.c
  - add small chunk test. It improves test coverage
  - add M5 test case that verify big integers overflow issue.
  - simplify "do_digest" by using built in openssl EVP_Digest instead bunch of method calls.  
  
test_grasshopper.c
  - fix  issue with compilers not fully supported C99 variable length arrays .