### PR TITLE
speedup: gosthash2012

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,27 +10,65 @@ enable_testing()
 find_package(OpenSSL 1.1.1 REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
 
-if (CMAKE_C_COMPILER_ID MATCHES "Clang")
- add_compile_options(-O2 -Werror -Wall -Wno-unused-parameter -Wno-unused-function -Wno-missing-braces -ggdb -Qunused-arguments)
-elseif(CMAKE_C_COMPILER_ID MATCHES "GNU")
- add_compile_options(-O2 -Werror -Wall -Wno-unused-parameter -Wno-unused-function -Wno-missing-braces -ggdb)
-elseif(CMAKE_C_COMPILER_ID MATCHES "MSVC")
+if(NOT CMAKE_BUILD_TYPE)
+ if (ASAN)
+  set(CMAKE_BUILD_TYPE Debug)
+ else()
+  set(CMAKE_BUILD_TYPE Release)
+ endif()
+endif()
+
+set(CMAKE_C_FLAGS_RELEASE "-O2")
+
+IF(CMAKE_C_COMPILER_ID MATCHES "Clang")
+ set(GCC_COMPATIBLE_COMPILER 1)
+ set(CMAKE_C_FLAGS_DEBUG "-ggdb")
+ add_compile_options(-Werror -Wall -Wno-unused-parameter -Wno-unused-function -Wno-missing-braces -Qunused-arguments)
+ELSEIF(CMAKE_C_COMPILER_ID MATCHES "GNU|ICC")
+ set(GCC_COMPATIBLE_COMPILER 1)
+ set(CMAKE_C_FLAGS_DEBUG "-ggdb")
+ add_compile_options(-Werror -Wall -Wno-unused-parameter -Wno-unused-function -Wno-missing-braces)
+ELSEIF(CMAKE_C_COMPILER_ID MATCHES "MSVC")
+ set(MSVC_COMPATIBLE_COMPILER 1)
  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
  add_definitions(-D_CRT_DEPRECATED_NO_WARNINGS)
  add_definitions(-D_CRT_NONSTDC_NO_WARNINGS)
- add_compile_options(/MP /WX /W4 /wd4100 /wd4267 /wd4206 /wd4706 /wd4244 /wd4115)
+ add_compile_options(/MP /WX /W4 /wd4100 /wd4267 /wd4706  /TC)
+ENDIF()
+
+cmake_host_system_information(RESULT  CPU_HAS_SSE2 QUERY HAS_SSE2)
+
+IF(CPU_HAS_SSE2 AND NOT NO_SIMD)
+ message("build SSE2 optimized library. Add  NO_SIMD parameter to turn SSE off")
+ add_definitions(-DENABLE_SIMD)
+ IF(GCC_COMPATIBLE_COMPILER)
+  #ensure compiler turn SIMD flags and intrinsics on
+  add_compile_options(-march=native)
+ ELSEIF(MSVC_COMPATIBLE_COMPILER)
+  message("to turn on SSE2/AVX optimization on Windows uncomment appropriate option line!")
+  #MSVC require further survey of system capabilities  (SSE4.1,AVX)
+  #but current version of CMAKE (3.16) lack of such feature
+  #uncomment one of the next line to build GOST Engine boosted by SSE/AVX 
+  
+  #add_compile_options(/arch:AVX512)
+  add_compile_options(/arch:AVX2)
+  #add_compile_options(/arch:AVX)
+  #add_compile_options(/arch:SSE2)
+  
+ ENDIF()
+ENDIF()
+
+if(ASAN)
+ message(STATUS "address sanitizer enabled")
+ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -g3 -fno-omit-frame-pointer")
 endif()
 
-if (ASAN)
-  message(STATUS "address sanitizer enabled")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -g3 -fno-omit-frame-pointer")
-endif()
-
-set(CMAKE_C_STANDARD 90)
+set(CMAKE_C_STANDARD 99)
 CHECK_FUNCTION_EXISTS(clock_gettime HAVE_CLOCK_GETTIME_C)
 CHECK_LIBRARY_EXISTS(rt clock_gettime "" HAVE_CLOCK_GETTIME_RT)
+
 if(HAVE_CLOCK_GETTIME_RT AND NOT HAVE_CLOCK_GETTIME_C)
-  set(CLOCK_GETTIME_LIB rt)
+ set(CLOCK_GETTIME_LIB rt)
 endif()
 
 include (TestBigEndian)
@@ -42,14 +80,16 @@ else()
  add_definitions(-DL_ENDIAN)
 endif()
 
+if(FORCE_UNALIGNED_MEM_ACCESS)
+ add_definitions(-DFORCE_UNALIGNED_MEM_ACCESS)
+endif()
+
 set(BIN_DIRECTORY bin)
 
 # Same soversion as OpenSSL
 set(GOST_SOVERSION "${OPENSSL_VERSION_MAJOR}.${OPENSSL_VERSION_MINOR}")
 
 set(OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${BIN_DIRECTORY})
-
-#set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${OUTPUT_DIRECTORY})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${OUTPUT_DIRECTORY})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_DIRECTORY})
 
@@ -120,6 +160,7 @@ set (GOST_OMAC_SOURCE_FILES
         )
 
 set(GOST_LIB_SOURCE_FILES
+		${GOST_CORE_SOURCE_FILES}
         ${GOST_89_SOURCE_FILES}
         ${GOST_HASH_SOURCE_FILES}
         ${GOST_HASH_2012_SOURCE_FILES}
@@ -138,42 +179,48 @@ set(GOST_ENGINE_SOURCE_FILES
         gost_omac_acpkm.c
         )
 
-add_executable(test_digest test_digest.c)
+#tests
+add_executable(test_digest test_digest.c ansi_terminal.c)
 target_link_libraries(test_digest gost_engine gost_core ${OPENSSL_CRYPTO_LIBRARY})
 add_test(NAME digest
 	COMMAND test_digest)
 
-add_executable(test_curves test_curves.c)
+add_executable(test_curves test_curves.c ansi_terminal.c)
 target_link_libraries(test_curves gost_engine gost_core ${OPENSSL_CRYPTO_LIBRARY})
 add_test(NAME curves
 	COMMAND test_curves)
 
-add_executable(test_params test_params.c)
+add_executable(test_params test_params.c ansi_terminal.c)
 target_link_libraries(test_params gost_engine gost_core ${OPENSSL_CRYPTO_LIBRARY})
 add_test(NAME parameters
 	COMMAND test_params)
 
-add_executable(test_sign test_sign.c)
+add_executable(test_sign test_sign.c ansi_terminal.c)
 target_link_libraries(test_sign gost_engine gost_core ${OPENSSL_CRYPTO_LIBRARY})
 add_test(NAME sign/verify
 	COMMAND test_sign)
 
-add_executable(test_tls test_tls.c)
+IF(NOT MSVC)
+
+add_executable(test_tls test_tls.c ansi_terminal.c)
 target_link_libraries(test_tls gost_engine gost_core ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
 add_test(NAME TLS
 	COMMAND test_tls)
+ELSE()
+message(WARNING  "test_tls build is skipped. Windows platform doesn't support some POSIX API ")
+ENDIF()
 
-add_executable(test_context test_context.c)
+add_executable(test_context test_context.c ansi_terminal.c)
 target_link_libraries(test_context gost_engine gost_core ${OPENSSL_CRYPTO_LIBRARY})
 add_test(NAME context
 	COMMAND test_context)
 
-add_executable(test_grasshopper test_grasshopper.c)
+add_executable(test_grasshopper test_grasshopper.c ansi_terminal.c)
 target_link_libraries(test_grasshopper gost_engine gost_core ${OPENSSL_CRYPTO_LIBRARY})
 add_test(NAME grasshopper
 	COMMAND test_grasshopper)
 
-add_executable(test_keyexpimp test_keyexpimp.c)
+add_executable(test_keyexpimp test_keyexpimp.c ansi_terminal.c)
 #target_compile_definitions(test_keyexpimp PUBLIC -DOPENSSL_LOAD_CONF)
 target_link_libraries(test_keyexpimp gost_engine gost_core ${OPENSSL_CRYPTO_LIBRARY})
 add_test(NAME keyexpimp
@@ -192,11 +239,10 @@ set_tests_properties(engine PROPERTIES ENVIRONMENT
 	"OPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR};OPENSSL_ENGINES=${OUTPUT_DIRECTORY};OPENSSL_CONF=${CMAKE_SOURCE_DIR}/test/empty.cnf")
 endif()
 
-add_executable(bench_digest benchmark/digest.c ansi_terminal.c)
-target_link_libraries(bench_digest gost_engine gost_core ${OPENSSL_CRYPTO_LIBRARY} ${CLOCK_GETTIME_LIB})
-
-add_executable(bench_sign benchmark/sign.c ansi_terminal.c)
-target_link_libraries(bench_sign gost_engine gost_core ${OPENSSL_CRYPTO_LIBRARY} ${CLOCK_GETTIME_LIB})
+add_executable(test_tlstree test_tlstree.c)
+target_link_libraries(test_tlstree PUBLIC ${OPENSSL_CRYPTO_LIBRARY})
+add_test(NAME test_tlstree
+	COMMAND test_tlstree)
 
 # All that may need to load just built engine will have path to it defined.
 set(BINARY_TESTS_TARGETS
@@ -208,10 +254,15 @@ set(BINARY_TESTS_TARGETS
         test_grasshopper
         test_keyexpimp
         test_gost89
-	test_tls
-        )
+        
+    )
+IF(NOT MSVC)
+list(APPEND BINARY_TESTS_TARGETS test_tls)
+ENDIF()
+
 set_property(TARGET ${BINARY_TESTS_TARGETS} APPEND PROPERTY COMPILE_DEFINITIONS ENGINE_DIR="${OUTPUT_DIRECTORY}")
 
+#core library
 add_library(gost_core STATIC ${GOST_LIB_SOURCE_FILES})
 set_target_properties(gost_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
@@ -219,37 +270,48 @@ add_library(gost_engine SHARED ${GOST_ENGINE_SOURCE_FILES})
 set_target_properties(gost_engine PROPERTIES PREFIX "" OUTPUT_NAME "gost")
 set_target_properties(gost_engine PROPERTIES VERSION ${GOST_SOVERSION} SOVERSION ${GOST_SOVERSION})
 target_link_libraries(gost_engine gost_core ${OPENSSL_CRYPTO_LIBRARY})
+if(WIN32)
+  target_link_libraries(gost_engine wsock32 ws2_32)
+endif()
 
+#utilities
 set(GOST_SUM_SOURCE_FILES
         gostsum.c
-        )
+    )
 
 add_executable(gostsum ${GOST_SUM_SOURCE_FILES})
 target_link_libraries(gostsum gost_core)
 
 set(GOST_12_SUM_SOURCE_FILES
         gost12sum.c
-        )
+    )
 
 add_executable(gost12sum ${GOST_12_SUM_SOURCE_FILES})
 target_link_libraries(gost12sum gost_core)
+
+#benchmarks
+add_executable(bench_digest benchmark/digest.c ansi_terminal.c)
+target_link_libraries(bench_digest gost_engine gost_core ${OPENSSL_CRYPTO_LIBRARY} ${CLOCK_GETTIME_LIB})
+
+add_executable(bench_sign benchmark/sign.c ansi_terminal.c)
+target_link_libraries(bench_sign gost_engine gost_core ${OPENSSL_CRYPTO_LIBRARY} ${CLOCK_GETTIME_LIB})
+
+IF(NOT MSVC)
 
 set_source_files_properties(tags PROPERTIES GENERATED true)
 add_custom_target(tags
     COMMAND ctags -R . ${OPENSSL_ROOT_DIR}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-add_executable(test_tlstree test_tlstree.c)
-target_link_libraries(test_tlstree PUBLIC ${OPENSSL_CRYPTO_LIBRARY})
-
-# install
+	
 set(OPENSSL_MAN_INSTALL_DIR ${CMAKE_INSTALL_MANDIR}/man1)
 
 install(TARGETS gost_engine gostsum gost12sum EXPORT GostEngineConfig
         LIBRARY  DESTINATION ${OPENSSL_ENGINES_DIR}
         RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES gostsum.1 gost12sum.1 DESTINATION ${OPENSSL_MAN_INSTALL_DIR})
-if (MSVC)
+
+ELSE()
  install(FILES $<TARGET_PDB_FILE:gost_engine> DESTINATION ${OPENSSL_ENGINES_DIR} OPTIONAL)
  install(FILES $<TARGET_PDB_FILE:gostsum> $<TARGET_PDB_FILE:gost12sum> DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL)
-endif()
+ENDIF()
+

--- a/gosthash2012.c
+++ b/gosthash2012.c
@@ -9,11 +9,17 @@
  */
 
 #include "gosthash2012.h"
+#include <assert.h>
 
-#if defined(_WIN32) || defined(_WINDOWS)
-# define INLINE __inline
-#else
-# define INLINE inline
+#ifdef __x86_64__
+
+# include <immintrin.h>
+# ifdef __clang__
+# elif __GNUC__
+#  include <x86intrin.h>
+# else
+#  include <intrin.h>
+# endif
 #endif
 
 #define BSWAP64(x) \
@@ -37,77 +43,62 @@ void init_gost2012_hash_ctx(gost2012_hash_ctx * CTX,
     CTX->digest_size = digest_size;
     if (digest_size == 256)
         memset(&CTX->h, 0x01, sizeof(uint512_u));
-    else
-        memset(&CTX->h, 0x00, sizeof(uint512_u));
 }
 
 static INLINE void pad(gost2012_hash_ctx * CTX)
-{
-    unsigned char buf[64];
-
-    if (CTX->bufsize > 63)
-        return;
-
-    memset(&buf, 0x00, sizeof buf);
-    memcpy(&buf, CTX->buffer, CTX->bufsize);
-
-    buf[CTX->bufsize] = 0x01;
-    memcpy(CTX->buffer, &buf, sizeof buf);
+{    
+    assert( CTX->bufsize < 64 );
+    
+    memset(&(CTX->buffer.B[CTX->bufsize]), 0x00, sizeof(CTX->buffer) - CTX->bufsize  );
+    CTX->buffer.B[CTX->bufsize] = 0x01;
 }
 
-static INLINE void add512(const union uint512_u *x,
-                          const union uint512_u *y, union uint512_u *r)
+static INLINE void add512(union uint512_u * RESTRICT x, const union uint512_u * UNALIGNED RESTRICT y)
 {
-#ifndef __GOST3411_BIG_ENDIAN__
-    unsigned int CF, OF;
-    unsigned long long tmp;
+    
+#ifdef __x86_64__
+    unsigned char CF=0;
     unsigned int i;
-
-    CF = 0;
+    
     for (i = 0; i < 8; i++)
     {
-        /* Detecting integer overflow condition for three numbers
-         * in a portable way is tricky a little. */
-
-        /* Step 1: numbers cause overflow */
-        tmp = x->QWORD[i] + y->QWORD[i];
-
-        /* Compare with any of two summands, no need to check both */
-        if (tmp < x->QWORD[i])
-            OF = 1;
-        else
-            OF = 0;
-
-        /* Step 2: carry bit causes overflow */
-        tmp += CF;
-
-        if (CF > 0 && tmp == 0)
-            OF = 1;
-
-        CF = OF;
-
-        r->QWORD[i] = tmp;
+        CF = _addcarry_u64(CF, x->QWORD[i] , y->QWORD[i], &(x->QWORD[i]) );     
     }
-#else
-    const unsigned char *xp, *yp;
-    unsigned char *rp;
+    
+#elif __GOST3411_BIG_ENDIAN__
+    const unsigned char *yp;
+    unsigned char *xp;
     unsigned int i;
     int buf;
 
-    xp = (const unsigned char *)&x[0];
+    xp = (unsigned char *)&x[0];
     yp = (const unsigned char *)&y[0];
-    rp = (unsigned char *)&r[0];
+    
 
     buf = 0;
     for (i = 0; i < 64; i++) {
         buf = xp[i] + yp[i] + (buf >> 8);
-        rp[i] = (unsigned char)buf & 0xFF;
+        xp[i] = (unsigned char)buf & 0xFF;
+    }
+#else
+    unsigned long CF=0;
+    unsigned long long tmp;
+    unsigned int i;
+
+    for (i = 0; i < 8; i++)
+    {
+        tmp = x->QWORD[i] + y->QWORD[i] + CF;
+    
+        if (tmp != x->QWORD[i])
+            CF = (tmp < x->QWORD[i]);
+        
+        x->QWORD[i] = tmp;        
     }
 #endif
 }
 
-static void g(union uint512_u *h, const union uint512_u *N,
-              const unsigned char *m)
+static void g(union uint512_u * RESTRICT h, const union uint512_u * RESTRICT N,
+              const union uint512_u * UNALIGNED RESTRICT m)
 {
 #ifdef __GOST3411_HAS_SSE2__
     __m128i xmm0, xmm2, xmm4, xmm6; /* XMMR0-quadruple */
@@ -116,8 +107,8 @@ static void g(union uint512_u *h, const union uint512_u *N,
 
     LOAD(N, xmm0, xmm2, xmm4, xmm6);
     XLPS128M(h, xmm0, xmm2, xmm4, xmm6);
+    ULOAD(m, xmm1, xmm3, xmm5, xmm7);
 
-    LOAD(m, xmm1, xmm3, xmm5, xmm7);
     XLPS128R(xmm0, xmm2, xmm4, xmm6, xmm1, xmm3, xmm5, xmm7);
 
     for (i = 0; i < 11; i++)
@@ -127,12 +118,14 @@ static void g(union uint512_u *h, const union uint512_u *N,
     X128R(xmm0, xmm2, xmm4, xmm6, xmm1, xmm3, xmm5, xmm7);
 
     X128M(h, xmm0, xmm2, xmm4, xmm6);
-    X128M(m, xmm0, xmm2, xmm4, xmm6);
+    ULOAD(m, xmm1, xmm3, xmm5, xmm7);
+    X128R(xmm0, xmm2, xmm4, xmm6, xmm1, xmm3, xmm5, xmm7);
 
-    UNLOAD(h, xmm0, xmm2, xmm4, xmm6);
-
-    /* Restore the Floating-point status on the CPU */
+    STORE(h, xmm0, xmm2, xmm4, xmm6);
+#if 0
+    /* Restore the Floating-point status on the CPU. Require only for MMX version */
     _mm_empty();
+#endif    
 #else
     union uint512_u Ki, data;
     unsigned int i;
@@ -151,48 +144,36 @@ static void g(union uint512_u *h, const union uint512_u *N,
     /* E() done */
 
     X((&data), h, (&data));
-    X((&data), ((const union uint512_u *)&m[0]), h);
+    X((&data), m, h);
 #endif
 }
 
-static INLINE void stage2(gost2012_hash_ctx * CTX, const unsigned char *data)
+static INLINE void stage2(gost2012_hash_ctx * CTX, const union uint512_u * UNALIGNED data)
 {
-    union uint512_u m;
+    g(&(CTX->h), &(CTX->N), data );
 
-    memcpy(&m, data, sizeof(m));
-    g(&(CTX->h), &(CTX->N), (const unsigned char *)&m);
-
-    add512(&(CTX->N), &buffer512, &(CTX->N));
-    add512(&(CTX->Sigma), &m, &(CTX->Sigma));
+    add512(&(CTX->N), &buffer512);
+    add512(&(CTX->Sigma), data );
 }
 
 static INLINE void stage3(gost2012_hash_ctx * CTX)
 {
-    ALIGN(16) union uint512_u buf;
-
-    memset(&buf, 0x00, sizeof buf);
-    memcpy(&buf, &(CTX->buffer), CTX->bufsize);
-    memcpy(&(CTX->buffer), &buf, sizeof(uint512_u));
-
-    memset(&buf, 0x00, sizeof buf);
-#ifndef __GOST3411_BIG_ENDIAN__
-    buf.QWORD[0] = CTX->bufsize << 3;
-#else
-    buf.QWORD[0] = BSWAP64(CTX->bufsize << 3);
-#endif
-
     pad(CTX);
 
-    g(&(CTX->h), &(CTX->N), (const unsigned char *)&(CTX->buffer));
+    g(&(CTX->h), &(CTX->N), &(CTX->buffer) );
 
-    add512(&(CTX->N), &buf, &(CTX->N));
-    add512(&(CTX->Sigma), (const union uint512_u *)&CTX->buffer[0],
-           &(CTX->Sigma));
+    add512(&(CTX->Sigma), &(CTX->buffer));
 
-    g(&(CTX->h), &buffer0, (const unsigned char *)&(CTX->N));
-
-    g(&(CTX->h), &buffer0, (const unsigned char *)&(CTX->Sigma));
-    memcpy(&(CTX->hash), &(CTX->h), sizeof(uint512_u));
+    memset(&(CTX->buffer.B[0]), 0x00, sizeof(uint512_u) );  
+#ifndef __GOST3411_BIG_ENDIAN__
+    CTX->buffer.QWORD[0] = CTX->bufsize << 3;
+#else
+    CTX->buffer.QWORD[0] = BSWAP64(CTX->bufsize << 3);
+#endif
+       
+    add512(&(CTX->N), &(CTX->buffer));
+    g(&(CTX->h), &buffer0, &(CTX->N));
+    g(&(CTX->h), &buffer0, &(CTX->Sigma));
 }
 
 /*
@@ -200,34 +181,41 @@ static INLINE void stage3(gost2012_hash_ctx * CTX)
  *
  */
 void gost2012_hash_block(gost2012_hash_ctx * CTX,
-                         const unsigned char *data, size_t len)
+                         const unsigned char * data, size_t len)
 {
-    size_t chunksize;
-
-    while (len > 63 && CTX->bufsize == 0) {
-        stage2(CTX, data);
-
-        data += 64;
-        len -= 64;
-    }
-
+    register size_t chunksize;
+    register size_t bufsize = CTX->bufsize;
+    
+    if(bufsize==0){
+        while(len>=64){
+#ifdef UNALIGNED_MEM_ACCESS
+            stage2(CTX, (const union uint512_u *)data );
+#else
+            memcpy(&CTX->buffer.B[0], data, 64);
+                stage2(CTX, &(CTX->buffer) );
+#endif
+            len   -= 64;
+            data  += 64;            
+        }
+    }   
+        
     while (len) {
-        chunksize = 64 - CTX->bufsize;
+        chunksize = 64 - bufsize;
         if (chunksize > len)
             chunksize = len;
 
-        memcpy(&CTX->buffer[CTX->bufsize], data, chunksize);
+        memcpy(&(CTX->buffer.B[bufsize]), data, chunksize);
 
-        CTX->bufsize += chunksize;
-        len -= chunksize;
-        data += chunksize;
+        bufsize += chunksize;
+        len     -= chunksize;
+        data    += chunksize;
 
-        if (CTX->bufsize == 64) {
-            stage2(CTX, CTX->buffer);
-
-            CTX->bufsize = 0;
+        if (bufsize == 64) {
+            stage2(CTX, &(CTX->buffer) );
+            bufsize = 0;
         }
     }
+    CTX->bufsize = bufsize;
 }
 
 /*
@@ -242,7 +230,7 @@ void gost2012_finish_hash(gost2012_hash_ctx * CTX, unsigned char *digest)
     CTX->bufsize = 0;
 
     if (CTX->digest_size == 256)
-        memcpy(digest, &(CTX->hash.QWORD[4]), 32);
+        memcpy(digest, &(CTX->h.QWORD[4]), 32);
     else
-        memcpy(digest, &(CTX->hash.QWORD[0]), 64);
+        memcpy(digest, &(CTX->h.QWORD[0]), 64);
 }

--- a/gosthash2012.h
+++ b/gosthash2012.h
@@ -10,27 +10,61 @@
 
 #include <string.h>
 
-#ifdef OPENSSL_IA32_SSE2
-# ifdef __MMX__
-#  ifdef __SSE2__
-#   define __GOST3411_HAS_SSE2__
-#  endif
+#if defined(_M_AMD64) || defined(_M_X64)
+# define __x86_64__
+#endif
+
+#ifdef ENABLE_SIMD
+# if defined(__SSE2__) || defined(_M_AMD64) || defined(_M_X64)
+#  define __GOST3411_HAS_SSE2__
+#  if !defined(__x86_64__)
+   /* x86-64 bit Linux and Windows ABIs provide malloc function that returns 16-byte alignment
+      memory buffers required by SSE load/store instructions. Other platforms require special trick  
+      for proper gost2012_hash_ctx structure allocation. It will be easier to switch to unaligned 
+      loadu/storeu memory access instructions in this case.
+   */  
+#   define UNALIGNED_MEM_ACCESS 
+#  endif   
 # endif
 #endif
 
 #ifdef __GOST3411_HAS_SSE2__
-# if (__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ < 2)
+# if defined(__GNUC__) && ((__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ < 2))
 #  undef __GOST3411_HAS_SSE2__
 # endif
+#else
+# if !defined(__i386__) && !defined(__x86_64__)
+ /*Assume other platforms are not capable unaligned memory read
+   or unaligned memory read is not fast enough 
+ */ 
+#  define UNALIGNED_MEM_ACCESS
+# endif
+#endif
+
+#ifdef FORCE_UNALIGNED_MEM_ACCESS  
+# define UNALIGNED_MEM_ACCESS
 #endif
 
 #ifndef L_ENDIAN
 # define __GOST3411_BIG_ENDIAN__
 #endif
+
 #if defined __GOST3411_HAS_SSE2__
 # include "gosthash2012_sse2.h"
 #else
 # include "gosthash2012_ref.h"
+#endif
+
+#if defined(_WIN32) || defined(_WINDOWS)
+# define INLINE __inline
+# ifdef __x86_64__
+#  define UNALIGNED __unaligned
+# else
+#  define UNALIGNED
+# endif 
+#else
+# define INLINE inline
+# define UNALIGNED 
 #endif
 
 #ifdef _MSC_VER
@@ -39,9 +73,20 @@
 # define ALIGN(x) __attribute__ ((__aligned__(x)))
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
+# define RESTRICT __restrict__
+#else
+# ifdef _MSC_VER
+#   define RESTRICT  __restrict
+# else  
+#   define RESTRICT
+# endif
+#endif
+
 ALIGN(16)
 typedef union uint512_u {
     unsigned long long QWORD[8];
+    unsigned char B[64];
 } uint512_u;
 
 #include "gosthash2012_const.h"
@@ -49,8 +94,7 @@ typedef union uint512_u {
 
 /* GOST R 34.11-2012 hash context */
 typedef struct gost2012_hash_ctx {
-    unsigned char buffer[64];
-    union uint512_u hash;
+    union uint512_u buffer;
     union uint512_u h;
     union uint512_u N;
     union uint512_u Sigma;

--- a/gosthash2012_sse2.h
+++ b/gosthash2012_sse2.h
@@ -12,8 +12,13 @@
 # error "GOST R 34.11-2012: SSE2 not enabled"
 #endif
 
+
 #include <mmintrin.h>
 #include <emmintrin.h>
+
+#ifdef __SSE3__
+#include <pmmintrin.h>
+#endif
 
 #define LO(v) ((unsigned char) (v))
 #define HI(v) ((unsigned char) (((unsigned int) (v)) >> 8))
@@ -29,20 +34,47 @@
 # define _mm_cvtm64_si64(v) (long long) v
 #endif
 
-#define LOAD(P, xmm0, xmm1, xmm2, xmm3) { \
-    const __m128i *__m128p = (const __m128i *) &P[0]; \
-    xmm0 = _mm_load_si128(&__m128p[0]); \
-    xmm1 = _mm_load_si128(&__m128p[1]); \
-    xmm2 = _mm_load_si128(&__m128p[2]); \
-    xmm3 = _mm_load_si128(&__m128p[3]); \
+# ifdef __SSE3__
+#   define UMEM_READ_I128 _mm_lddqu_si128  
+# else 
+#   define UMEM_READ_I128 _mm_loadu_si128
+# endif 
+
+/* load 512bit from unaligned memory  */
+#define ULOAD(P, xmm0, xmm1, xmm2, xmm3) { \
+    const __m128i *__m128p = (const __m128i *) P; \
+    xmm0 = UMEM_READ_I128(&__m128p[0]); \
+    xmm1 = UMEM_READ_I128(&__m128p[1]); \
+    xmm2 = UMEM_READ_I128(&__m128p[2]); \
+    xmm3 = UMEM_READ_I128(&__m128p[3]); \
 }
 
-#define UNLOAD(P, xmm0, xmm1, xmm2, xmm3) { \
+#ifdef UNALIGNED_MEM_ACCESS
+
+# define LOAD   ULOAD
+# define MEM_WRITE_I128  _mm_storeu_si128
+# define MEM_READ_I128   UMEM_READ_I128  
+
+#else
+ 
+# define MEM_WRITE_I128  _mm_store_si128
+# define MEM_READ_I128   _mm_load_si128
+# define LOAD(P, xmm0, xmm1, xmm2, xmm3) { \
+    const __m128i *__m128p = (const __m128i *) P; \
+    xmm0 = MEM_READ_I128(&__m128p[0]); \
+    xmm1 = MEM_READ_I128(&__m128p[1]); \
+    xmm2 = MEM_READ_I128(&__m128p[2]); \
+    xmm3 = MEM_READ_I128(&__m128p[3]); \
+}
+
+#endif
+
+#define STORE(P, xmm0, xmm1, xmm2, xmm3) { \
     __m128i *__m128p = (__m128i *) &P[0]; \
-    _mm_store_si128(&__m128p[0], xmm0); \
-    _mm_store_si128(&__m128p[1], xmm1); \
-    _mm_store_si128(&__m128p[2], xmm2); \
-    _mm_store_si128(&__m128p[3], xmm3); \
+    MEM_WRITE_I128(&__m128p[0], xmm0); \
+    MEM_WRITE_I128(&__m128p[1], xmm1); \
+    MEM_WRITE_I128(&__m128p[2], xmm2); \
+    MEM_WRITE_I128(&__m128p[3], xmm3); \
 }
 
 #define X128R(xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7) { \
@@ -54,10 +86,10 @@
 
 #define X128M(P, xmm0, xmm1, xmm2, xmm3) { \
     const __m128i *__m128p = (const __m128i *) &P[0]; \
-    xmm0 = _mm_xor_si128(xmm0, _mm_load_si128(&__m128p[0])); \
-    xmm1 = _mm_xor_si128(xmm1, _mm_load_si128(&__m128p[1])); \
-    xmm2 = _mm_xor_si128(xmm2, _mm_load_si128(&__m128p[2])); \
-    xmm3 = _mm_xor_si128(xmm3, _mm_load_si128(&__m128p[3])); \
+    xmm0 = _mm_xor_si128(xmm0, MEM_READ_I128(&__m128p[0])); \
+    xmm1 = _mm_xor_si128(xmm1, MEM_READ_I128(&__m128p[1])); \
+    xmm2 = _mm_xor_si128(xmm2, MEM_READ_I128(&__m128p[2])); \
+    xmm3 = _mm_xor_si128(xmm3, MEM_READ_I128(&__m128p[3])); \
 }
 
 #define _mm_xor_64(mm0, mm1) _mm_xor_si64(mm0, _mm_cvtsi64_m64(mm1))


### PR DESCRIPTION
CMakeList.txt
  - adapt for Windows Visual Studio compiler
  - group script blocks by category
  - remove some Windows warning suppressions. MSVC is more picky than GCC and it facilitates quality improvement
  - add SSE2 compiler options if current system support SIMD (. NO_SIMD flag used for bypass this 
  - change C standard to 99 as module code use C99 features by default
  - fix test_tlstree test. It was not in test bundle
  - exclude test_tls from Windows build scenario as test_tls.c use some POSIX methods unsupported by Windows. 
  - "sign" executable rename to "bench_sign" 
  - add new benchmark - "bench_digest"
  
gosthash2012.c
gosthash2012.h
gosthash2012_sse2.h
 - eliminate excessive memory allocations and moves
 - involve SSE2 optimized digest implementation.  
     - patch gosthash2012_sse2.h  to turn on unaligned memory  instructions for read input digest data 
	 - rename UNLOAD to STORE to avoid clash of UNLOAD and ULOAD (unaligned memory load)
	 - implement both fast aligned and a little slower unaligned memory access SIMD functions
	 - use the aligned memory function for access context fields on X86_64 , and the unaligned one on other platforms
 - optimize add512 function for x86 platform
 

 all improvements give more then 80% speedup
 
 GOST-R 34.11-2012(512). block size / digest speed, MBps
 Ubuntu Linux 18.04  amd65.  GOST ENGINE 1.1.1 . CPU Intel Core i5-4210U 1.70GHz. gcc 7.4.0 
	was
	#/size          32        64       256      1024      8192      9732     65536
	------------------------------------------------------------------------------
		   1      5.00     11.80     27.60     42.49     50.31     50.37     49.29
		   2      6.97     10.90     27.25     42.53     49.98     50.41     51.12
		   3      7.50     11.90     28.19     42.19     50.34     50.51     49.79
		   4      7.39     11.91     27.72     40.90     49.92     50.21     51.22
		   5      7.40     11.88     27.89     41.81     50.46     50.41     49.13
	------------------------------------------------------------------------------
	become
	#/size          32        64       256      1024      8192      9732     65536
	------------------------------------------------------------------------------
		   1     12.75     21.54     54.02     84.00    101.31    101.17     89.30
		   2     11.72     21.36     53.90     84.07     99.91    100.80    103.72
		   3     13.71     21.78     55.25     85.07    102.19    100.64    103.26
		   4     13.22     21.65     54.26     85.23    101.63    102.21     99.80
		   5     11.20     19.27     45.39     71.80     96.00    103.08    105.13
	------------------------------------------------------------------------------
  
  on Windows speedup is about 80%